### PR TITLE
fix: Minimize the admission of containers with the NET_RAW capability

### DIFF
--- a/base/values.yaml
+++ b/base/values.yaml
@@ -39,6 +39,9 @@ applications:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - "NET_RAW"
         ports:
           - name: http
             containerPort: 80
@@ -113,6 +116,9 @@ applications:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - "NET_RAW"
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
This capability allows a container to use raw and packet sockets, which can be exploited by attackers to conduct network attacks, spoofing, or to bypass network controls. Removing or not granting this capability is a recommended practice to enhance the security posture of your containers.